### PR TITLE
Restoring RUN variable back to it's original name

### DIFF
--- a/RELEASE_NOTE_ens_tracker_v1.3
+++ b/RELEASE_NOTE_ens_tracker_v1.3
@@ -1,3 +1,8 @@
+Release Note:  ens_tracker.v1.3.9 (2026/04/20)
+This release corrects an issue introduced in version 1.3.8. In the previous release, the RUN parameter was mistakenly defined as “gfs” instead of “gefs” in the jobs for GFS genesis and GFS track AVNX. The RUN value should be set to “gefs,” as GFS genesis and track are treated as members of the GEFS run. This update restores the configuration to its original, correct state.`
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
 Release Note:  ens_tracker.v1.3.8 (2025/11/25)
 Updated the enstrack.v1.3.8 package to include the new AIGFS v1.0, AIGEFS v1.0, and HGEFS models. The package can now generate track and mean ensemble data for both AIGFS and AIGEFS. Thehybrid ensemble mean is produced using the HGEFS run script, which must wait for the AIGEFS and GEFS runs to finish before it can execute. The package now includes three ecf scripts andthree jjobs to run each of the models. Two separate data_check and extrkr scripts have been added to process the AI models independently. The sorc codes have also been updated to incorporate all of these changes. An additional development directory has been added to support more efficient future testing.
 

--- a/dev/ecf/jgfs_tc_genesis.ecf
+++ b/dev/ecf/jgfs_tc_genesis.ecf
@@ -1,22 +1,34 @@
 #!/bin/bash
-#PBS -N ens_tracker_gfs_tc_genesis_%CYC%
+#PBS -N ens_tracker_gfs_tc_genesis_00
 #PBS -j oe
-#PBS -A %PROJ%-%PROJENVIR%
-#PBS -q %QUEUE%
+#PBS -A ENSTRACK-DEV
+#PBS -q dev
 #PBS -S /bin/bash
-#PBS -l select=1:ncpus=1:mem=4GB
-#PBS -l walltime=00:25:00
+#PBS -l select=5:ncpus=5:mem=20GB
+#PBS -l walltime=00:45:00
 #PBS -l debug=true
 
-export model=ens_tracker
-%include <head.h>
-%include <envir-p1.h>
+#export model=ens_tracker
+#%include <head.h>
+#%include <envir-p1.h>
 #
-export cyc=%CYC%
+#export cyc=%CYC%
+
+module reset
+export target=wcoss2
+source /lfs/h2/emc/ens/noscrub/hananeh.jafary/ens_tracker.v1.3.9/versions/run.ver
+#module use /lfs/h2/emc/ens/noscrub/hananeh.jafary/ens_package_08042025/modulefiles
+#module load ${target}.lua
+module list
 
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load intel/$intel_ver
 module load craype/$craype_ver
+
+module load cray-mpich/$cray_mpich_ver
+module load cray-pals/$cray_pals_ver
+
+module load prod_util/$prod_util_ver
 
 module load hdf5/$hdf5_ver
 module load netcdf/$netcdf_ver
@@ -35,12 +47,22 @@ module load wgrib2/$wgrib2_ver
 
 module list
 
+export model=ens_tracker
+export cyc=00
+export envir=prod
+export job=gfs_genesis_${cyc}
+export COMROOT=/lfs/h2/emc/ptmp/hananeh.jafary/com
+export DATAROOT=/lfs/h2/emc/ptmp/hananeh.jafary
+export KEEPDATA=YES
+
+export PACKAGEHOME=/lfs/h2/emc/ens/noscrub/hananeh.jafary/ens_tracker.v1.3.9
 # CALL executable job script here
-${HOMEens_tracker}/jobs/JGFS_TC_GENESIS
+
+${PACKAGEHOME}/dev/jobs/JGFS_TC_GENESIS
 
 
-%include <tail.h>
-%manual
+#%include <tail.h>
+#%manual
 ######################################################################
 #PURPOSE:  Executes the job that creates GFS TC genesis forecasts
 ######################################################################

--- a/dev/ecf/jgfs_tc_track_avnx.ecf
+++ b/dev/ecf/jgfs_tc_track_avnx.ecf
@@ -1,22 +1,34 @@
 #!/bin/bash
-#PBS -N ens_tracker_gfs_tc_track_avnx_%CYC%
+#PBS -N ens_tracker_gfs_tc_track_avnx_00
 #PBS -j oe
-#PBS -A %PROJ%-%PROJENVIR%
-#PBS -q %QUEUE%
+#PBS -A ENSTRACK-DEV
+#PBS -q dev
 #PBS -S /bin/bash
-#PBS -l select=1:ncpus=1:mem=4GB
-#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=3:ncpus=31:mpiprocs=31:mem=100GB
+#PBS -l walltime=00:45:00
 #PBS -l debug=true
 
-export model=ens_tracker
-%include <head.h>
-%include <envir-p1.h>
+#export model=ens_tracker
+#%include <head.h>
+#%include <envir-p1.h>
 #
-export cyc=%CYC%
+#export cyc=%CYC%
+
+module reset
+export target=wcoss2
+source /lfs/h2/emc/ens/noscrub/hananeh.jafary/ens_tracker.v1.3.9/versions/run.ver
+#module use /lfs/h2/emc/ens/noscrub/hananeh.jafary/ens_package_08042025/modulefiles
+#module load ${target}.lua
+module list
 
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load intel/$intel_ver
 module load craype/$craype_ver
+
+module load cray-mpich/$cray_mpich_ver
+module load cray-pals/$cray_pals_ver
+
+module load prod_util/$prod_util_ver
 
 module load hdf5/$hdf5_ver
 module load netcdf/$netcdf_ver
@@ -35,12 +47,20 @@ module load wgrib2/$wgrib2_ver
 
 module list
 
+export model=ens_tracker
+export cyc=12
+export envir=prod
+export job=gfs_avnx_${cyc}
+export COMROOT=/lfs/h2/emc/ptmp/hananeh.jafary/com
+export DATAROOT=/lfs/h2/emc/ptmp/hananeh.jafary
+export KEEPDATA=YES
+
+export PACKAGEHOME=/lfs/h2/emc/ens/noscrub/hananeh.jafary/ens_tracker.v1.3.9
 # CALL executable job script here
-${HOMEens_tracker}/jobs/JGFS_TC_TRACK_AVNX
+${PACKAGEHOME}/dev/jobs/JGFS_TC_TRACK_AVNX
 
-
-%include <tail.h> 
-%manual
+#%include <tail.h> 
+#%manual
 ######################################################################
 #PURPOSE:  Executes the job that creates GFS TC track forecasts
 ######################################################################
@@ -52,4 +72,4 @@ ${HOMEens_tracker}/jobs/JGFS_TC_TRACK_AVNX
 ######################################################################
 
 # include manual page below
-%end
+#%end

--- a/dev/jobs/JGFS_TC_GENESIS
+++ b/dev/jobs/JGFS_TC_GENESIS
@@ -49,9 +49,9 @@ export SCRIPTens_tracker=${SCRIPTens_tracker:-$HOMEens_tracker/scripts}
 ##############################
 # Run setpdy and initialize PDY variables
 ##############################
-setpdy.sh
-. ./PDY
-
+#setpdy.sh
+#. ./PDY
+export PDY=20260420
 ##############################################
 # Define COM directories
 ##############################################
@@ -60,10 +60,19 @@ export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}}
 export COMINsyn=${COMINsyn:-$(compath.py $envir/com/gfs/${gfs_ver})/syndat}
 
 export COMIN=${COMIN:-$(compath.py -o $NET/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/genesis}
-export COMINgenvit=${COMINgenvit:-$(compath.py -o ${NET}/${ens_tracker_ver})/genesis_vital_${JYYYY}}
+export COMINgenvit=${COMINgenvit:-$(compath.py ${NET}/${ens_tracker_ver})/genesis_vital_${JYYYY}}
 
-export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/genesis}
-export COMOUTgenvit=${COMOUTgenvit:-$(compath.py -o ${NET}/${ens_tracker_ver})/genesis_vital_${JYYYY}}
+export COMOUT=/lfs/h2/emc/ptmp/hananeh.jafary/genesis
+export COMOUTgenvit=/lfs/h2/emc/ptmp/hananeh.jafary/genesis/genesis_vital_${JYYYY}
+
+#export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}}
+#export COMINsyn=${COMINsyn:-$(compath.py $envir/com/gfs/${gfs_ver})/syndat}
+
+#export COMIN=${COMIN:-$(compath.py -o $NET/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/genesis}
+#export COMINgenvit=${COMINgenvit:-$(compath.py -o ${NET}/${ens_tracker_ver})/genesis_vital_${JYYYY}}
+
+#export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/genesis}
+#export COMOUTgenvit=${COMOUTgenvit:-$(compath.py -o ${NET}/${ens_tracker_ver})/genesis_vital_${JYYYY}}
 mkdir -m 775 -p $COMOUT $COMOUTgenvit
 
 msg="HAS BEGUN on `hostname`"

--- a/dev/jobs/JGFS_TC_TRACK_AVNX
+++ b/dev/jobs/JGFS_TC_TRACK_AVNX
@@ -49,22 +49,31 @@ export USHens_tracker=${USHens_tracker:-$HOMEens_tracker/ush}
 ##############################
 # Run setpdy and initialize PDY variables
 ##############################
-setpdy.sh
-. ./PDY
+#setpdy.sh
+#. ./PDY
+export PDY=20260420
 ##############################################
 # Define COM directories
 ##############################################
 export JYYYY=`echo ${PDY} | cut -c1-4`
-export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}}
-export COMINsyn=${COMINsyn:-$(compath.py $envir/com/gfs/${gfs_ver})/syndat}
+#export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}}
+#export COMINsyn=${COMINsyn:-$(compath.py $envir/com/gfs/${gfs_ver})/syndat}
 
-export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/tctrack}
-export COMOUThur=${COMOUThur:-$(compath.py -o ${NET}/${ens_tracker_ver})/global}
-export COMOUTatcf=${COMOUTatcf:-$(compath.py -o ${NET}/${ens_tracker_ver})/atcf}
+#export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/tctrack}
+#export COMOUThur=${COMOUThur:-$(compath.py -o ${NET}/${ens_tracker_ver})/global}
+#export COMOUTatcf=${COMOUTatcf:-$(compath.py -o ${NET}/${ens_tracker_ver})/atcf}
+
+export COMINgfs=/lfs/h1/ops/prod/com/gfs/v16.3/gfs.${PDY}
+export COMINsyn=/lfs/h1/ops/prod/com/gfs/v16.3/syndat
+
+export COMOUT=${COMOUT:-${COMROOT:?}/gfs.${PDY}/00/products/atmos/cyclone/tracks}
+export COMOUThur=${COMOUThur:-${COMROOT:?}/${NET}/${ens_tracker_ver}/global}
+export COMOUTatcf=${COMOUTatcf:-${COMROOT:?}/${NET}/${ens_tracker_ver}/atcf}
+
 mkdir -m 775 -p $COMOUT $COMOUThur $COMOUTatcf
 
 msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+#postmsg "$jlogfile" "$msg"
 
 env
 

--- a/jobs/JGFS_TC_GENESIS
+++ b/jobs/JGFS_TC_GENESIS
@@ -20,7 +20,7 @@ export cycle=t${cyc}z
 # Specify NET and RUN Name and model
 ####################################
 export NET=${NET:-ens_tracker}
-export RUN=${RUN:-gfs}
+export RUN=${RUN:-gefs}
 
 ####################################
 # Determine Job Output Name on System

--- a/jobs/JGFS_TC_TRACK_AVNX
+++ b/jobs/JGFS_TC_TRACK_AVNX
@@ -21,7 +21,7 @@ export ECMWF_FILE_EXT=${ECMWF_FILE_EXT:-1}
 # Specify NET and RUN Name and model
 ####################################
 export NET=${NET:-ens_tracker}
-export RUN=${RUN:-gfs}
+export RUN=${RUN:-gefs}
 
 ####################################
 # Determine Job Output Name on System


### PR DESCRIPTION
This release corrects an issue introduced in version 1.3.8. In the previous release, the RUN parameter was mistakenly defined as “gfs” instead of “gefs” in the jobs for GFS genesis and GFS track AVNX. The RUN value should be set to “gefs,” as GFS genesis and track are treated as members of the GEFS run. This update restores the configuration to its original, correct state.