### PR TITLE
Feature/ens tracker.v1.3.10

### DIFF
--- a/RELEASE_NOTE_ens_tracker_v1.4
+++ b/RELEASE_NOTE_ens_tracker_v1.4
@@ -1,3 +1,21 @@
+Release Note:  ens_tracker.v1.4.0 (2026/04/30)
+This update is to prepare the package for the new ECMWF data. Previously, ECMWF ensemble member runs used DCE files that included both perturbed and control members. In the updated dataset, control members are no longer included. As a result, any references to the control member (C00) have been removed from the EENS workflow. Control member runs are now handled separately within the ECMWF deterministic runs.
+
+The update is included in the following files:
+
+1. job/JEENS_TC_TRACK
+Removed control member (C00) since it is no longer present in the input files.
+2. job/JEENS_GRIB
+Updated ECMWF_FILE_EXT from 1 to 80.
+3. scripts/exeens_tc_genesis.sh
+Removed control member (C00) to align with updated input files.
+4. scripts/exwsr_ecmwfens.sh
+Updated ifile from DCD to DCE.
+5. ush/data_check.sh
+Updated datfile from DCD to DCE.
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+
 Release Note:  ens_tracker.v1.3.9 (2026/04/27)
 This release corrects an issue introduced in version 1.3.8. In the previous release, the RUN parameter was mistakenly defined as “gfs” instead of “gefs” in the jobs for GFS genesis and GFS track AVNX. The RUN value should be set to “gefs,” as GFS genesis and track are treated as members of the GEFS run. This update restores the configuration to its original, correct state.
 

--- a/RELEASE_NOTE_ens_tracker_v1.4
+++ b/RELEASE_NOTE_ens_tracker_v1.4
@@ -5,14 +5,10 @@ The update is included in the following files:
 
 1. job/JEENS_TC_TRACK
 Removed control member (C00) since it is no longer present in the input files.
-2. job/JEENS_GRIB
-Updated ECMWF_FILE_EXT from 1 to 80.
-3. scripts/exeens_tc_genesis.sh
+2. scripts/exeens_tc_genesis.sh
 Removed control member (C00) to align with updated input files.
-4. scripts/exwsr_ecmwfens.sh
+3. scripts/exwsr_ecmwfens.sh
 Updated ifile from DCD to DCE.
-5. ush/data_check.sh
-Updated datfile from DCD to DCE.
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/dev/ecf/jecmwf_tc_genesis.ecf
+++ b/dev/ecf/jecmwf_tc_genesis.ecf
@@ -1,18 +1,34 @@
 #!/bin/bash
-#PBS -N ens_tracker_ecmwf_tc_genesis_%CYC%
+#PBS -N ens_tracker_ecmwf_tc_genesis
 #PBS -j oe
-#PBS -A %PROJ%-%PROJENVIR%
-#PBS -q %QUEUE%
+#PBS -A ENSTRACK-DEV
+#PBS -q dev
 #PBS -S /bin/bash
-#PBS -l select=1:ncpus=1:mem=4GB
+#PBS -l select=1:ncpus=1:mem=8GB
 #PBS -l walltime=01:05:00
 #PBS -l debug=true
 
-export model=ens_tracker
-%include <head.h>
-%include <envir-p1.h>
+#export model=ens_tracker
+#%include <head.h>
+#%include <envir-p1.h>
 #
-export cyc=%CYC%
+#export cyc=%CYC%
+
+module reset
+export target=wcoss2
+module use /lfs/h2/emc/ens/noscrub/hananeh.jafary/ens_package_08042025/modulefiles
+module load ${target}.lua
+module list
+
+export cyc=00
+export model=ens_tracker
+export envir=prod
+export job=ecmwf_genesis_${cyc}
+export COMROOT=/lfs/h2/emc/ptmp/hananeh.jafary/com
+export DATAROOT=/lfs/h2/emc/ptmp/hananeh.jafary
+export KEEPDATA=YES
+
+export PACKAGEHOME=/lfs/h2/emc/ens/noscrub/hananeh.jafary/ens_tracker.v1.4.0
 
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load intel/$intel_ver
@@ -36,7 +52,7 @@ module load wgrib2/$wgrib2_ver
 module list
 
 # CALL executable job script here
-${HOMEens_tracker}/jobs/JECMWF_TC_GENESIS
+${PACKAGEHOME}/dev/jobs/JECMWF_TC_GENESIS
 
 %include <tail.h>
 %manual

--- a/dev/ecf/jecmwf_tc_track.ecf
+++ b/dev/ecf/jecmwf_tc_track.ecf
@@ -1,18 +1,33 @@
 #!/bin/bash
-#PBS -N ens_tracker_ecmwf_tc_track_%CYC%
+#PBS -N ens_tracker_ecmwf_tc_track
 #PBS -j oe
-#PBS -A %PROJ%-%PROJENVIR%
-#PBS -q %QUEUE%
+#PBS -A ENSTRACK-DEV
+#PBS -q dev
 #PBS -S /bin/bash
-#PBS -l select=1:ncpus=1:mem=4GB
+#PBS -l select=1:ncpus=1:mem=8GB
 #PBS -l walltime=01:05:00
 #PBS -l debug=true
 
-export model=ens_tracker
-%include <head.h>
-%include <envir-p1.h>
+#export model=ens_tracker
+#%include <head.h>
+#%include <envir-p1.h>
 #
-export cyc=%CYC%
+
+module reset
+export target=wcoss2
+module use /lfs/h2/emc/ens/noscrub/hananeh.jafary/ens_package_08042025/modulefiles
+module load ${target}.lua
+module list
+
+export cyc=00
+export model=ens_tracker
+export envir=prod
+export job=ecmwf_track_${cyc}
+export COMROOT=/lfs/h2/emc/ptmp/hananeh.jafary/com
+export DATAROOT=/lfs/h2/emc/ptmp/hananeh.jafary
+export KEEPDATA=YES
+
+export PACKAGEHOME=/lfs/h2/emc/ens/noscrub/hananeh.jafary/ens_tracker.v1.4.0
 
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load intel/$intel_ver
@@ -33,13 +48,14 @@ module load libjpeg/$libjpeg_ver
 module load grib_util/$grib_util_ver
 module load wgrib2/$wgrib2_ver
 
+
 module list
 
 # CALL executable job script here
-${HOMEens_tracker}/jobs/JECMWF_TC_TRACK
+${PACKAGEHOME}/dev/jobs/JECMWF_TC_TRACK
 
-%include <tail.h>
-%manual
+#%include <tail.h>
+#%manual
 ######################################################################
 #PURPOSE:  Executes the job that creates ECMWF TC track forecasts
 ######################################################################
@@ -51,4 +67,4 @@ ${HOMEens_tracker}/jobs/JECMWF_TC_TRACK
 ######################################################################
 
 # include manual page below
-%end
+#%end

--- a/dev/ecf/jeens_grib.ecf
+++ b/dev/ecf/jeens_grib.ecf
@@ -1,19 +1,26 @@
 #!/bin/bash
-#PBS -N ens_tracker_eens_grib_%CYC% 
+#PBS -N ens_tracker_eens_grib 
 #PBS -j oe
-#PBS -A %PROJ%-%PROJENVIR%
-#PBS -q %QUEUE%
+#PBS -A ENSTRACK-DEV
+#PBS -q dev
 #PBS -S /bin/bash
 #PBS -l place=vscatter,select=3:ncpus=41:mpiprocs=41:mem=40GB
 #PBS -l walltime=01:15:00
 #PBS -l debug=true
 
-export model=ens_tracker
-%include <head.h>
-%include <envir-p1.h>
+#export model=ens_tracker
+#%include <head.h>
+#%include <envir-p1.h>
 #
-export cyc=%CYC%
+#export cyc=%CYC%
 
+module reset
+export target=wcoss2
+module use /lfs/h2/emc/ens/noscrub/hananeh.jafary/ens_package_08042025/modulefiles
+module load ${target}.lua
+module list
+
+module load wgrib2/2.0.8
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load intel/$intel_ver
 module load craype/$craype_ver
@@ -36,8 +43,18 @@ module load wgrib2/$wgrib2_ver
 module load cray-pals/$cray_pals_ver
 module list
 
+export model=ens_tracker
+export cyc=00
+export envir=prod
+export job=eens_grib_${cyc}
+export COMROOT=/lfs/h2/emc/ptmp/hananeh.jafary/com
+export DATAROOT=/lfs/h2/emc/ptmp/hananeh.jafary
+export KEEPDATA=YES
+
+export PACKAGEHOME=/lfs/h2/emc/ens/noscrub/hananeh.jafary/ens_tracker.v1.4.0
+
 # CALL executable job script here
-${HOMEens_tracker}/jobs/JEENS_GRIB
+${PACKAGEHOME}/dev/jobs/JEENS_GRIB
 
 %include <tail.h>
 %manual

--- a/dev/ecf/jeens_tc_genesis.ecf
+++ b/dev/ecf/jeens_tc_genesis.ecf
@@ -1,18 +1,24 @@
 #!/bin/bash
-#PBS -N ens_tracker_eens_tc_genesis_%CYC%
+#PBS -N ens_tracker_eens_tc_genesis
 #PBS -j oe
-#PBS -A %PROJ%-%PROJENVIR%
-#PBS -q %QUEUE%
+#PBS -A ENSTRACK-DEV
+#PBS -q dev
 #PBS -S /bin/bash
 #PBS -l place=vscatter,select=3:ncpus=51:mpiprocs=51:mem=40GB
 #PBS -l walltime=00:40:00
 #PBS -l debug=true
 
-export model=ens_tracker
-%include <head.h>
-%include <envir-p1.h>
+#export model=ens_tracker
+#%include <head.h>
+#%include <envir-p1.h>
 #
-export cyc=%CYC%
+#export cyc=%CYC%
+
+module reset
+export target=wcoss2
+module use /lfs/h2/emc/ens/noscrub/hananeh.jafary/ens_package_08042025/modulefiles
+module load ${target}.lua
+module list
 
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load intel/$intel_ver
@@ -36,8 +42,18 @@ module load wgrib2/$wgrib2_ver
 module load cray-pals/$cray_pals_ver
 module list
 
+export model=ens_tracker
+export cyc=00
+export envir=prod
+export job=eens_track_${cyc}
+export COMROOT=/lfs/h2/emc/ptmp/hananeh.jafary/com
+export DATAROOT=/lfs/h2/emc/ptmp/hananeh.jafary
+export KEEPDATA=YES
+
+export PACKAGEHOME=/lfs/h2/emc/ens/noscrub/hananeh.jafary/ens_tracker.v1.4.0
+
 # CALL executable job script here
-${HOMEens_tracker}/jobs/JEENS_TC_GENESIS
+${PACKAGEHOME}/dev/jobs/JEENS_TC_GENESIS
 
 %include <tail.h>
 %manual

--- a/dev/ecf/jeens_tc_track.ecf
+++ b/dev/ecf/jeens_tc_track.ecf
@@ -1,19 +1,24 @@
 #!/bin/bash
-#PBS -N ens_tracker_eens_tc_track_%CYC%
+#PBS -N ens_tracker_eens_tc_track
 #PBS -j oe
-#PBS -A %PROJ%-%PROJENVIR%
-#PBS -q %QUEUE%
+#PBS -A ENSTRACK-DEV
+#PBS -q dev
 #PBS -S /bin/bash
-#PBS -l place=vscatter,select=3:ncpus=51:mpiprocs=51:mem=4GB
-#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=3:ncpus=51:mpiprocs=51:mem=8GB
+#PBS -l walltime=00:20:00
 #PBS -l debug=true
 
-export model=ens_tracker
-%include <head.h>
-%include <envir-p1.h>
+#export model=ens_tracker
+#%include <head.h>
+#%include <envir-p1.h>
 #
-export cyc=%CYC%
+#export cyc=%CYC%
 
+module reset
+export target=wcoss2
+module use /lfs/h2/emc/ens/noscrub/hananeh.jafary/ens_package_08042025/modulefiles
+module load ${target}.lua
+module list
 
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load intel/$intel_ver
@@ -37,8 +42,18 @@ module load wgrib2/$wgrib2_ver
 module load cray-pals/$cray_pals_ver
 module list
 
+export model=ens_tracker
+export cyc=00
+export envir=prod
+export job=eens_track_${cyc}
+export COMROOT=/lfs/h2/emc/ptmp/hananeh.jafary/com
+export DATAROOT=/lfs/h2/emc/ptmp/hananeh.jafary
+export KEEPDATA=YES
+
+export PACKAGEHOME=/lfs/h2/emc/ens/noscrub/hananeh.jafary/ens_tracker.v1.4.0
+
 # CALL executable job script here
-${HOMEens_tracker}/jobs/JEENS_TC_TRACK
+${PACKAGEHOME}/dev/jobs/JEENS_TC_TRACK
 
 %include <tail.h>
 %manual

--- a/dev/ecf/jemy_tc_track.ecf
+++ b/dev/ecf/jemy_tc_track.ecf
@@ -1,18 +1,34 @@
 #!/bin/bash
-#PBS -N ens_tracker_emy_tc_track_%CYC%
+#PBS -N ens_tracker_emy_tc_track
 #PBS -j oe
-#PBS -A %PROJ%-%PROJENVIR%
-#PBS -q %QUEUE%
+#PBS -A ENSTRACK-DEV
+#PBS -q dev
 #PBS -S /bin/bash
 #PBS -l select=1:ncpus=1:mem=4GB
 #PBS -l walltime=01:05:00
 #PBS -l debug=true
 
-export model=ens_tracker
-%include <head.h>
-%include <envir-p1.h>
+#export model=ens_tracker
+#%include <head.h>
+#%include <envir-p1.h>
 #
-export cyc=%CYC%
+#export cyc=%CYC%
+
+module reset
+export target=wcoss2
+source /lfs/h2/emc/ens/noscrub/hananeh.jafary/ecmwf_50r1_03242026/ens_tracker.v1.3.7/versions/run.ver
+module load ${target}.lua
+module list
+
+export cyc=00
+export model=ens_tracker
+export envir=prod
+export job=ecmwf_track_${cyc}
+export COMROOT=/lfs/h2/emc/ptmp/hananeh.jafary/com
+export DATAROOT=/lfs/h2/emc/ptmp/hananeh.jafary
+export KEEPDATA=YES
+
+export PACKAGEHOME=/lfs/h2/emc/ens/noscrub/hananeh.jafary/ecmwf_50r1_03242026/ens_tracker.v1.3.7
 
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load intel/$intel_ver
@@ -33,10 +49,12 @@ module load libjpeg/$libjpeg_ver
 module load grib_util/$grib_util_ver
 module load wgrib2/$wgrib2_ver
 
+module load prod_util/2.0.13
+
 module list
 
 # CALL executable job script here
-${HOMEens_tracker}/jobs/JEMY_TC_TRACK
+${PACKAGEHOME}/dev/jobs/JEMY_TC_TRACK
 
 %include <tail.h> 
 %manual

--- a/dev/ecf/jgefs_tc_track.ecf
+++ b/dev/ecf/jgefs_tc_track.ecf
@@ -1,24 +1,18 @@
 #!/bin/bash
-#PBS -N ens_tracker_gefs_tc_track
+#PBS -N ens_tracker_gefs_tc_track_%CYC%
 #PBS -j oe
-#PBS -A ENSTRACK-DEV
-#PBS -q dev
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -q %QUEUE%
 #PBS -S /bin/bash
-#PBS -l place=vscatter,select=3:ncpus=31:mpiprocs=31:mem=200GB
+#PBS -l place=vscatter,select=3:ncpus=31:mpiprocs=31:mem=100GB
 #PBS -l walltime=00:25:00
 #PBS -l debug=true
 
 export model=ens_tracker
-export cyc=00
-export envir=prod
-export job=gefs_avno_${cyc}
-export COMROOT=/lfs/h2/emc/ptmp/hananeh.jafary/com
-export DATAROOT=/lfs/h2/emc/ptmp/hananeh.jafary
-export KEEPDATA=YES
-export PACKAGEHOME=/lfs/h2/emc/ens/noscrub/hananeh.jafary/aigfs/ens_tracker
-
-module reset
-source /lfs/h2/emc/ens/noscrub/hananeh.jafary/aigfs/ens_tracker/versions/run.ver
+%include <head.h>
+%include <envir-p1.h>
+#
+export cyc=%CYC%
 
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load intel/$intel_ver
@@ -40,13 +34,11 @@ module load libjpeg/$libjpeg_ver
 module load grib_util/$grib_util_ver
 module load wgrib2/$wgrib2_ver
 
-module load prod_envir/$prod_envir_ver
-module load prod_util/$prod_util_ver
-
 module list
 
 # CALL executable job script here
-${PACKAGEHOME}/dev/jobs/JGEFS_TC_TRACK
+${HOMEens_tracker}/jobs/JGEFS_TC_TRACK
+
 
 %include <tail.h>
 %manual

--- a/dev/jobs/JECMWF_TC_GENESIS
+++ b/dev/jobs/JECMWF_TC_GENESIS
@@ -50,20 +50,29 @@ export SCRIPTens_tracker=${SCRIPTens_tracker:-$HOMEens_tracker/scripts}
 ##############################
 # Run setpdy and initialize PDY variables
 ##############################
-setpdy.sh
-. ./PDY
-
+#setpdy.sh
+#. ./PDY
+export PDY=20260316
 ##############################################
 # Define COM directories
 ##############################################
 export JYYYY=`echo ${PDY} | cut -c1-4`
-export DCOM=${DCOM:-/lfs/h1/ops/prod/dcom/${PDY}/wgrbbul/ecmwf}
-export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}}
-export COMINsyn=${COMINsyn:-$(compath.py $envir/com/gfs/${gfs_ver})/syndat}
-export COMINgenvit=${COMINgenvit:-$(compath.py -o ${NET}/${ens_tracker_ver})/genesis_vital_${JYYYY}}
+#export DCOM=${DCOM:-/lfs/h1/ops/prod/dcom/${PDY}/wgrbbul/ecmwf}
+#export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}}
+#export COMINsyn=${COMINsyn:-$(compath.py $envir/com/gfs/${gfs_ver})/syndat}
+#export COMINgenvit=${COMINgenvit:-$(compath.py -o ${NET}/${ens_tracker_ver})/genesis_vital_${JYYYY}}
 
-export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/genesis}
-export COMOUTgenvit=${COMOUTgenvit:-$(compath.py -o ${NET}/${ens_tracker_ver})/genesis_vital_${JYYYY}}
+#export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/genesis}
+#export COMOUTgenvit=${COMOUTgenvit:-$(compath.py -o ${NET}/${ens_tracker_ver})/genesis_vital_${JYYYY}}
+
+export DCOM=${DCOM:-/lfs/h2/emc/ens/noscrub/hananeh.jafary/ecmwf_50r1_03242026/20260316/ecmwf}
+export COMINgfs=/lfs/h1/ops/prod/com/gfs/v16.3/gfs.${PDY}
+export COMINsyn=/lfs/h1/ops/prod/com/gfs/v16.3/syndat
+
+export COMOUT=/lfs/h2/emc/ptmp/hananeh.jafary/tctrack
+export COMINgenvit=/lfs/h2/emc/ptmp/hananeh.jafary/genesis_vital_${JYYYY}
+export COMOUTgenvit=/lfs/h2/emc/ptmp/hananeh.jafary/genesis_vital_${JYYYY}
+
 mkdir -m 775 -p $COMOUT $COMOUTgenvit
 
 msg="HAS BEGUN on `hostname`"

--- a/dev/jobs/JECMWF_TC_TRACK
+++ b/dev/jobs/JECMWF_TC_TRACK
@@ -17,6 +17,7 @@ export cycle=t${cyc}z
 #export jlogfile=${jlogfile:-${DATA}/jlogfile.${jobid}}
 
 export ECMWF_FILE_EXT=${ECMWF_FILE_EXT:-1}
+#export ECMWF_FILE_EXT=80
 ####################################
 # Specify NET and RUN Name and model
 ####################################
@@ -49,20 +50,24 @@ export USHens_tracker=${USHens_tracker:-$HOMEens_tracker/ush}
 ##############################
 # Run setpdy and initialize PDY variables
 ##############################
-setpdy.sh
-. ./PDY
-
+#setpdy.sh
+#. ./PDY
+export PDY=20260316
 ##############################################
 # Define COM directories
 ##############################################
-export DCOM=${DCOM:-/lfs/h1/ops/prod/dcom/${PDY}/wgrbbul/ecmwf}
-export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}}
-export COMINsyn=${COMINsyn:-$(compath.py $envir/com/gfs/${gfs_ver})/syndat}
+export DCOM=${DCOM:-/lfs/h2/emc/ens/noscrub/hananeh.jafary/ecmwf_50r1_03242026/20260316/ecmwf}
+export COMINgfs=/lfs/h1/ops/prod/com/gfs/v16.3/gfs.${PDY}
+export COMINsyn=/lfs/h1/ops/prod/com/gfs/v16.3/syndat
 
+#export COMOUT=${COMOUT:-${COMROOT:?}/ecmwf.${PDY}/${cyc}/products/atmos/cyclone/tracks}
+#export COMOUThur=${COMOUThur:-$(compath.py -o ${NET}/${ens_tracker_ver})/global}
+#export COMOUTatcf=${COMOUTatcf:-$(compath.py -o ${NET}/${ens_tracker_ver})/atcf}
 
-export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/tctrack}
-export COMOUThur=${COMOUThur:-$(compath.py -o ${NET}/${ens_tracker_ver})/global}
-export COMOUTatcf=${COMOUTatcf:-$(compath.py -o ${NET}/${ens_tracker_ver})/atcf}
+export COMOUT=/lfs/h2/emc/ptmp/hananeh.jafary/tctrack
+export COMOUThur=/lfs/h2/emc/ptmp/hananeh.jafary/global
+export COMOUTatcf=/lfs/h2/emc/ptmp/hananeh.jafary/atcf
+
 mkdir -m 775 -p $COMOUT $COMOUThur $COMOUTatcf
 
 msg="HAS BEGUN on `hostname`"
@@ -82,9 +87,9 @@ pertdir=${DATA}/${cmodel}/${pert}
 mkdir -p $pertdir
 
 #-----------input data checking -----------------
-${USHens_tracker}/data_check.sh
+#${USHens_tracker}/data_check.sh
 # exit code 6 = missing data of opportunity
-if [ $? -eq 6 ]; then exit; fi
+#if [ $? -eq 6 ]; then exit; fi
 #------------------------------------------------
 
 ${USHens_tracker}/extrkr_g1.sh ${ymdh} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}
@@ -97,7 +102,7 @@ export err=$?; err_chk
 #############################################################
 
 msg="JOB COMPLETED NORMALLY"
-postmsg "$jlogfile" "$msg"
+#postmsg "$jlogfile" "$msg"
 
 ##############################
 # Remove the Temporary working directory

--- a/dev/jobs/JEENS_GRIB
+++ b/dev/jobs/JEENS_GRIB
@@ -17,6 +17,7 @@ export cycle=t${cyc}z
 #export jlogfile=${jlogfile:-${DATA}/jlogfile.${jobid}}
 
 export ECMWF_FILE_EXT=${ECMWF_FILE_EXT:-1}
+export ECMWF_FILE_EXT=80
 ####################################
 # Specify NET and RUN Name and model
 ####################################
@@ -50,14 +51,16 @@ export SCRIPTSens_tracker=${SCRIPTSens_tracker:-$HOMEens_tracker/scripts}
 ##############################
 # Run setpdy and initialize PDY variables
 ##############################
-setpdy.sh
-. ./PDY
-
+#setpdy.sh
+#. ./PDY
+export PDY=20260316
 ##############################################
 # Define COM directories
 ##############################################
-export DCOM=${DCOM:-/lfs/h1/ops/prod/dcom/${PDY}/wgrbbul/ecmwf}
-export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/pgrba}
+#export DCOM=${DCOM:-/lfs/h1/ops/prod/dcom/${PDY}/wgrbbul/ecmwf}
+#export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/pgrba}
+export DCOM=${DCOM:-/lfs/h2/emc/ens/noscrub/hananeh.jafary/ecmwf_50r1_03242026/${PDY}/ecmwf}
+export COMOUT=/lfs/h2/emc/ptmp/hananeh.jafary/pgrba
 mkdir -m 775 -p $COMOUT
 
 msg="HAS BEGUN on `hostname`"
@@ -81,6 +84,7 @@ if [ $? -eq 6 ]; then exit; fi
 
 #for MPMD runs
 cd ${DATA}
+#hrstring="  0"
 hrstring="  0   6  12  18  24  30  36  42  48  54
            60  66  72  78  84  90  96 102 108 114
           120 126 132 138 144 150 156 162 168 174

--- a/dev/jobs/JEENS_TC_GENESIS
+++ b/dev/jobs/JEENS_TC_GENESIS
@@ -49,19 +49,26 @@ export SCRIPTens_tracker=${SCRIPTens_tracker:-$HOMEens_tracker/scripts}
 ##############################
 # Run setpdy and initialize PDY variables
 ##############################
-setpdy.sh
-. ./PDY
-
+#setpdy.sh
+#. ./PDY
+export PDY=20260316
 ##############################################
 # Define COM directories
 ##############################################
 export JYYYY=`echo ${PDY} | cut -c1-4`
-export COMIN=${COMIN:-$(compath.py -o $NET/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/pgrba}
-export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}}
-export COMINsyn=${COMINsyn:-$(compath.py $envir/com/gfs/${gfs_ver})/syndat}
-export COMINgenvit=${COMINgenvit:-$(compath.py -o ${NET}/${ens_tracker_ver})/genesis_vital_${JYYYY}}
+export COMIN=/lfs/h2/emc/ptmp/hananeh.jafary/pgrba
+export COMINgfs=/lfs/h1/ops/prod/com/gfs/v16.3/gfs.${PDY}
+export COMINsyn=/lfs/h1/ops/prod/com/gfs/v16.3/syndat
 
-export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/genesis}
+export COMINgenvit=/lfs/h2/emc/ptmp/hananeh.jafary/genesis_vital_${JYYYY}
+export COMOUT=/lfs/h2/emc/ptmp/hananeh.jafary/genesis
+
+#export COMIN=${COMIN:-$(compath.py -o $NET/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/pgrba}
+#export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}}
+#export COMINsyn=${COMINsyn:-$(compath.py $envir/com/gfs/${gfs_ver})/syndat}
+#export COMINgenvit=${COMINgenvit:-$(compath.py -o ${NET}/${ens_tracker_ver})/genesis_vital_${JYYYY}}
+
+#export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/genesis}
 mkdir -m 775 -p $COMOUT
 
 msg="HAS BEGUN on `hostname`"

--- a/dev/jobs/JEENS_TC_TRACK
+++ b/dev/jobs/JEENS_TC_TRACK
@@ -48,19 +48,24 @@ export USHens_tracker=${USHens_tracker:-$HOMEens_tracker/ush}
 ##############################
 # Run setpdy and initialize PDY variables
 ##############################
-setpdy.sh
-. ./PDY
-
+#setpdy.sh
+#. ./PDY
+export PDY=20260316
 ##############################################
 # Define COM directories
 ##############################################
-export COMIN=${COMIN:-$(compath.py -o $NET/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/pgrba}
-export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}}
-export COMINsyn=${COMINsyn:-$(compath.py $envir/com/gfs/${gfs_ver})/syndat}
+#export COMIN=${COMIN:-$(compath.py -o $NET/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/pgrba}
+export COMIN=/lfs/h2/emc/ptmp/hananeh.jafary/pgrba
+export COMINgfs=/lfs/h1/ops/prod/com/gfs/v16.3/gfs.${PDY}
+export COMINsyn=/lfs/h1/ops/prod/com/gfs/v16.3/syndat
 
-export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/tctrack}
-export COMOUThur=${COMOUThur:-$(compath.py -o ${NET}/${ens_tracker_ver})/global}
-export COMOUTatcf=${COMOUTatcf:-$(compath.py -o ${NET}/${ens_tracker_ver})/atcf}
+#export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/tctrack}
+#export COMOUThur=${COMOUThur:-$(compath.py -o ${NET}/${ens_tracker_ver})/global}
+#export COMOUTatcf=${COMOUTatcf:-$(compath.py -o ${NET}/${ens_tracker_ver})/atcf}
+export COMOUT=/lfs/h2/emc/ptmp/hananeh.jafary/tctrack
+export COMOUThur=/lfs/h2/emc/ptmp/hananeh.jafary/global
+export COMOUTatcf=/lfs/h2/emc/ptmp/hananeh.jafary/atcf
+
 mkdir -m 775 -p $COMOUT $COMOUThur $COMOUTatcf
 
 msg="HAS BEGUN on `hostname`"
@@ -83,7 +88,8 @@ pertstring="p01 p02 p03 p04 p05 p06 p07 p08 p09 p10
             p21 p22 p23 p24 p25
             n01 n02 n03 n04 n05 n06 n07 n08 n09 n10
             n11 n12 n13 n14 n15 n16 n17 n18 n19 n20
-            n21 n22 n23 n24 n25 c00"
+            n21 n22 n23 n24 n25"
+
 
 >trkr.cmdfile
 for pert in ${pertstring}; do
@@ -93,12 +99,16 @@ for pert in ${pertstring}; do
   echo "${USHens_tracker}/extrkr_g1.sh ${ymdh} ${cmodel} ${pert} ${pertdir} 2>&1 >${outfile}" >>trkr.cmdfile
 done
 
+
+
 chmod u+x trkr.cmdfile
 export MP_PGMMODEL=mpmd
 export MP_CMDFILE=${DATA}/${cmodel}/trkr.cmdfile
 
 mpiexec --cpu-bind core --configfile ${MP_CMDFILE}
 export err=$?; err_chk
+
+
 
 #if [ ${SENDCOM} = 'NO' ]; then
 #  for pert in ${pertstring}; do

--- a/dev/jobs/JEMY_TC_TRACK
+++ b/dev/jobs/JEMY_TC_TRACK
@@ -14,7 +14,6 @@ export cycle=t${cyc}z
 ####################################
 # File To Log Msgs
 ####################################
-
 export ECMWF_FILE_EXT=${ECMWF_FILE_EXT:-1}
 ####################################
 # Specify NET and RUN Name and model
@@ -48,20 +47,27 @@ export USHens_tracker=${USHens_tracker:-$HOMEens_tracker/ush}
 ##############################
 # Run setpdy and initialize PDY variables
 ##############################
-setpdy.sh
-. ./PDY
-
+#setpdy.sh
+#. ./PDY
+export PDY=20260316
 ##############################################
 # Define COM directories
 ##############################################
-export DCOM=${DCOM:-/lfs/h1/ops/prod/dcom/${PDY}/wgrbbul/ecmwf}
-export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}}
-export COMINsyn=${COMINsyn:-$(compath.py $envir/com/gfs/${gfs_ver})/syndat}
+#export DCOM=${DCOM:-/lfs/h1/ops/prod/dcom/${PDY}/wgrbbul/ecmwf}
+#export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}}
+#export COMINsyn=${COMINsyn:-$(compath.py $envir/com/gfs/${gfs_ver})/syndat}
+export DCOM=${DCOM:-/lfs/h2/emc/ens/noscrub/hananeh.jafary/ecmwf_50r1_03242026/20260316/ecmwf}
+export COMINgfs=/lfs/h1/ops/prod/com/gfs/v16.3/gfs.${PDY}
+export COMINsyn=/lfs/h1/ops/prod/com/gfs/v16.3/syndat
 
+#export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/tctrack}
+#export COMOUThur=${COMOUThur:-$(compath.py -o ${NET}/${ens_tracker_ver})/global}
+#export COMOUTatcf=${COMOUTatcf:-$(compath.py -o ${NET}/${ens_tracker_ver})/atcf}
 
-export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/tctrack}
-export COMOUThur=${COMOUThur:-$(compath.py -o ${NET}/${ens_tracker_ver})/global}
-export COMOUTatcf=${COMOUTatcf:-$(compath.py -o ${NET}/${ens_tracker_ver})/atcf}
+export COMOUT=/lfs/h2/emc/ptmp/hananeh.jafary/tctrack
+export COMOUThur=/lfs/h2/emc/ptmp/hananeh.jafary/global
+export COMOUTatcf=/lfs/h2/emc/ptmp/hananeh.jafary/atcf
+
 mkdir -m 775 -p $COMOUT $COMOUThur $COMOUTatcf
 
 msg="HAS BEGUN on `hostname`"

--- a/dev/jobs/JGEFS_TC_TRACK
+++ b/dev/jobs/JGEFS_TC_TRACK
@@ -50,7 +50,7 @@ export USHens_tracker=${USHens_tracker:-$HOMEens_tracker/ush}
 ##############################
 setpdy.sh
 . ./PDY
-export PDY=20251124
+
 ##############################################
 # Define COM directories
 ##############################################
@@ -59,12 +59,9 @@ export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}}
 export COMINsyn=${COMINsyn:-$(compath.py $envir/com/gfs/${gfs_ver})/syndat}
 export COMINgefs=${COMINgefs:-$(compath.py $envir/com/gefs/${gefs_ver})/gefs.${PDY}/${cyc}}
 
-#export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/tctrack}
-#export COMOUThur=${COMOUThur:-$(compath.py -o ${NET}/${ens_tracker_ver})/global}
-#export COMOUTatcf=${COMOUTatcf:-$(compath.py -o ${NET}/${ens_tracker_ver})/atcf}
-export COMOUT=/lfs/h2/emc/ptmp/hananeh.jafary/${RUN}/tctrack
-export COMOUThur=/lfs/h2/emc/ptmp/hananeh.jafary/${RUN}/global
-export COMOUTatcf=/lfs/h2/emc/ptmp/hananeh.jafary/${RUN}/atcf
+export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${ens_tracker_ver})/${RUN}.${PDY}/${cyc}/tctrack}
+export COMOUThur=${COMOUThur:-$(compath.py -o ${NET}/${ens_tracker_ver})/global}
+export COMOUTatcf=${COMOUTatcf:-$(compath.py -o ${NET}/${ens_tracker_ver})/atcf}
 mkdir -m 775 -p $COMOUT $COMOUThur $COMOUTatcf
 
 msg="HAS BEGUN on `hostname`"

--- a/jobs/JEENS_TC_TRACK
+++ b/jobs/JEENS_TC_TRACK
@@ -83,7 +83,7 @@ pertstring="p01 p02 p03 p04 p05 p06 p07 p08 p09 p10
             p21 p22 p23 p24 p25
             n01 n02 n03 n04 n05 n06 n07 n08 n09 n10
             n11 n12 n13 n14 n15 n16 n17 n18 n19 n20
-            n21 n22 n23 n24 n25 c00"
+            n21 n22 n23 n24 n25"
 
 >trkr.cmdfile
 for pert in ${pertstring}; do

--- a/scripts/exeens_tc_genesis.sh
+++ b/scripts/exeens_tc_genesis.sh
@@ -26,7 +26,7 @@ pertstring="p01 p02 p03 p04 p05 p06 p07 p08 p09 p10\
             p21 p22 p23 p24 p25 \
             n01 n02 n03 n04 n05 n06 n07 n08 n09 n10\
             n11 n12 n13 n14 n15 n16 n17 n18 n19 n20\
-            n21 n22 n23 n24 n25 c00"
+            n21 n22 n23 n24 n25"
 
 >trkr.cmdfile
 for pert in ${pertstring}; do

--- a/scripts/exwsr_ecmwfens.sh
+++ b/scripts/exwsr_ecmwfens.sh
@@ -80,152 +80,152 @@ echo "The time just before copying begins is: `date`"
 
 #  let hourinc=hourix*12
 #  let hourinc=hourix*6
-  vymdh=` ${NDATE:?} ${hourinc} ${ymdh}`
-  vmdh=`  echo ${vymdh} | cut -c5-10`
-  vhour=` ${NHOUR:?} ${vymdh} ${ymdh}`
+vymdh=` ${NDATE:?} ${hourinc} ${ymdh}`
+vmdh=`  echo ${vymdh} | cut -c5-10`
+vhour=` ${NHOUR:?} ${vymdh} ${ymdh}`
 
-  echo `date` begin "vmdh = $vmdh"
+echo `date` begin "vmdh = $vmdh"
 
   # Construct the ECMWF file name.
   # Each file name contains the initial time and
   # the time at which the forecast is valid.
 
-  #ifil=ecens_DCE${imdh}00${vmdh}001
-  ifil=DCE${imdh}00${vmdh}00${ECMWF_FILE_EXT}
+ifil=DCE${imdh}00${vmdh}00${ECMWF_FILE_EXT}
+#  ifil=DCD${imdh}00${vmdh}00${ECMWF_FILE_EXT}
 
 #---J.Peng----2010-12-13--------------------------------------
 #  ifile=${dcom}/$PDY/wgrbbul/$ifil
-  ifile=${INDATA}/$ifil
-  echo "ifile = $ifile"
+ifile=${INDATA}/$ifil
+echo "ifile = $ifile"
 
-  let attempts=1
-  while [ $attempts -le 30 ]; do
-     if [ -s $ifile ]; then
-        break
-     else
-        sleep 60
-        let attempts=attempts+1
-     fi
-  done
-  if [ $attempts -gt 30 ] && [ ! -s $ifile ]; then
-     set +x; echo " "
-     echo "FATAL ERROR:  $ifile still not available after waiting 30 minutes... exiting"
-     echo " "; set -x
-     err_exit
+let attempts=1
+while [ $attempts -le 30 ]; do
+  if [ -s $ifile ]; then
+    break
+  else
+    sleep 60
+    let attempts=attempts+1
   fi
+done
+if [ $attempts -gt 30 ] && [ ! -s $ifile ]; then
+  set +x; echo " "
+  echo "FATAL ERROR:  $ifile still not available after waiting 30 minutes... exiting"
+  echo " "; set -x
+  err_exit
+fi
 
   # Copy the file from dcom
-  cpreq $ifile $ifil
+cpreq $ifile $ifil
 
   # The reason we need to use that Fortran program is we need to change
   # the GRIB file from ECMWF GRIB format to NCEP GRIB format.
-  $wgribx -s $ifil -d all -grib -o eccut.${ymdh}.f${vhour}
+$wgribx -s $ifil -d all -grib -o eccut.${ymdh}.f${vhour}
 
-  echo " "
-  echo "*---------------------------------------------------*"
-  echo "  Now in forecast part for ftime= ${hourinc}"
-  echo "*---------------------------------------------------*"
-  echo " "
+echo " "
+echo "*---------------------------------------------------*"
+echo "  Now in forecast part for ftime= ${hourinc}"
+echo "*---------------------------------------------------*"
+echo " "
 
-  resflag=2
+resflag=2
 
-  echo "FORECAST: ftype= DCE, ftime= $hourinc"
+echo "FORECAST: ftype= DCE, ftime= $hourinc"
 #------J.Peng----2010-12-13-----------------------------------
+export pgm=wsr_ecmwfensh
+. prep_step
+
+export XLFUNIT_11="eccut.${ymdh}.f${vhour}"
+${GRBINDEX:?} $XLFUNIT_11 eccut.${ymdh}.f${vhour}.i
+export XLFUNIT_21="eccut.${ymdh}.f${vhour}.i"
+
+export XLFUNIT_51="tmpt200"
+export XLFUNIT_151="tmpt200stat"
+export XLFUNIT_52="tmpt500"
+export XLFUNIT_152="tmpt500stat"
+export XLFUNIT_53="tmpt700"
+export XLFUNIT_153="tmpt700stat"
+export XLFUNIT_54="tmpt850"
+export XLFUNIT_154="tmpt850stat"
+export XLFUNIT_55="tmpt2m"
+export XLFUNIT_155="tmpt2mstat"
+export XLFUNIT_56="tmpt2max"
+export XLFUNIT_156="tmpt2maxstat"
+export XLFUNIT_57="tmpt2min"
+export XLFUNIT_157="tmpt2minstat"
+export XLFUNIT_58="tmptd2m"
+export XLFUNIT_158="tmptd2mstat"
+
+export XLFUNIT_61="tmpz200"
+export XLFUNIT_161="tmpz200stat"
+export XLFUNIT_62="tmpz500"
+export XLFUNIT_162="tmpz500stat"
+export XLFUNIT_63="tmpz700"
+export XLFUNIT_163="tmpz700stat"
+export XLFUNIT_64="tmpz850"
+export XLFUNIT_164="tmpz850stat"
+export XLFUNIT_65="tmpz1000"
+export XLFUNIT_165="tmpz1000stat"
+
+export XLFUNIT_71="tmprh500"
+export XLFUNIT_171="tmprh500stat"
+export XLFUNIT_72="tmprh700"
+export XLFUNIT_172="tmprh700stat"
+export XLFUNIT_73="tmprh850"
+export XLFUNIT_173="tmprh850stat"
+
+export XLFUNIT_81="tmpmslp"
+export XLFUNIT_181="tmpmslpstat"
+export XLFUNIT_82="tmppsfc"
+export XLFUNIT_182="tmppsfcstat"
+export XLFUNIT_83="tmpprcp"
+export XLFUNIT_183="tmpprcpstat"
+export XLFUNIT_84="tmptcdc"
+export XLFUNIT_184="tmptcdcstat"
+
+export XLFUNIT_101="tmpu200"
+export XLFUNIT_102="tmpv200"
+export XLFUNIT_103="tmpu500"
+export XLFUNIT_104="tmpv500"
+export XLFUNIT_105="tmpu700"
+export XLFUNIT_106="tmpv700"
+export XLFUNIT_107="tmpu850"
+export XLFUNIT_108="tmpv850"
+export XLFUNIT_109="tmpu10m"
+export XLFUNIT_110="tmpv10m"
+
+echo " &namin"                                      >input1
+echo "    kres=${resflag},kmaxmem=${maxmem}"       >>input1
+echo " /"                                          >>input1
+
+if [ -s eccut.${ymdh}.f${vhour} ]
+then
+  set +x
+  echo "File ${ifil} is copied/wgribbed as eccut.${ymdh}.f${vhour}"
+  echo "Now converting format..."
+  set -x
+
   export pgm=wsr_ecmwfensh
+  msg="$pgm start for eens_grib1 at ${ymdh}_${vhour}"
+  postmsg "$jlogfile" "$msg"
   . prep_step
+  startmsg
+  ${EXECecme}/wsr_ecmwfensh <input1 >ec.DCE.f${vhour} >> $pgmout 2> errfile
+  ecmwfrcc=$?
 
-  export XLFUNIT_11="eccut.${ymdh}.f${vhour}"
-  ${GRBINDEX:?} $XLFUNIT_11 eccut.${ymdh}.f${vhour}.i
-  export XLFUNIT_21="eccut.${ymdh}.f${vhour}.i"
-
-  export XLFUNIT_51="tmpt200"
-  export XLFUNIT_151="tmpt200stat"
-  export XLFUNIT_52="tmpt500"
-  export XLFUNIT_152="tmpt500stat"
-  export XLFUNIT_53="tmpt700"
-  export XLFUNIT_153="tmpt700stat"
-  export XLFUNIT_54="tmpt850"
-  export XLFUNIT_154="tmpt850stat"
-  export XLFUNIT_55="tmpt2m"
-  export XLFUNIT_155="tmpt2mstat"
-  export XLFUNIT_56="tmpt2max"
-  export XLFUNIT_156="tmpt2maxstat"
-  export XLFUNIT_57="tmpt2min"
-  export XLFUNIT_157="tmpt2minstat"
-  export XLFUNIT_58="tmptd2m"
-  export XLFUNIT_158="tmptd2mstat"
-
-  export XLFUNIT_61="tmpz200"
-  export XLFUNIT_161="tmpz200stat"
-  export XLFUNIT_62="tmpz500"
-  export XLFUNIT_162="tmpz500stat"
-  export XLFUNIT_63="tmpz700"
-  export XLFUNIT_163="tmpz700stat"
-  export XLFUNIT_64="tmpz850"
-  export XLFUNIT_164="tmpz850stat"
-  export XLFUNIT_65="tmpz1000"
-  export XLFUNIT_165="tmpz1000stat"
-
-  export XLFUNIT_71="tmprh500"
-  export XLFUNIT_171="tmprh500stat"
-  export XLFUNIT_72="tmprh700"
-  export XLFUNIT_172="tmprh700stat"
-  export XLFUNIT_73="tmprh850"
-  export XLFUNIT_173="tmprh850stat"
-
-  export XLFUNIT_81="tmpmslp"
-  export XLFUNIT_181="tmpmslpstat"
-  export XLFUNIT_82="tmppsfc"
-  export XLFUNIT_182="tmppsfcstat"
-  export XLFUNIT_83="tmpprcp"
-  export XLFUNIT_183="tmpprcpstat"
-  export XLFUNIT_84="tmptcdc"
-  export XLFUNIT_184="tmptcdcstat"
-
-  export XLFUNIT_101="tmpu200"
-  export XLFUNIT_102="tmpv200"
-  export XLFUNIT_103="tmpu500"
-  export XLFUNIT_104="tmpv500"
-  export XLFUNIT_105="tmpu700"
-  export XLFUNIT_106="tmpv700"
-  export XLFUNIT_107="tmpu850"
-  export XLFUNIT_108="tmpv850"
-  export XLFUNIT_109="tmpu10m"
-  export XLFUNIT_110="tmpv10m"
-
-  echo " &namin"                                      >input1
-  echo "    kres=${resflag},kmaxmem=${maxmem}"       >>input1
-  echo " /"                                          >>input1
-
-  if [ -s eccut.${ymdh}.f${vhour} ]
-  then
-    set +x
-    echo "File ${ifil} is copied/wgribbed as eccut.${ymdh}.f${vhour}"
-    echo "Now converting format..."
-    set -x
-
-    export pgm=wsr_ecmwfensh
-    msg="$pgm start for eens_grib1 at ${ymdh}_${vhour}"
+  if [ ${ecmwfrcc} -eq 0 ]; then
+    msg="$pgm end for eens_grib1 at ${ymdh}_${vhour} completed normally"
     postmsg "$jlogfile" "$msg"
-    . prep_step
-    startmsg
-    ${EXECecme}/wsr_ecmwfensh <input1 >ec.DCE.f${vhour} >> $pgmout 2> errfile
-    ecmwfrcc=$?
-
-    if [ ${ecmwfrcc} -eq 0 ]; then
-      msg="$pgm end for eens_grib1 at ${ymdh}_${vhour} completed normally"
-      postmsg "$jlogfile" "$msg"
-    else
-      set +x
-      echo " "
-      echo "FATAL ERROR:  An error occurred while running wsr_ecmwfensh "
-      echo "!!! which is the program for ECgrib1-NCEPgrib1             "
-      echo "!!! Return code from wsr_ecmwfensh = ${ecmwfrcc} "
-      echo "!!! Exiting...at ${ymdh}_${vhour}"
-      echo " "
-      set -x
-      err_exit "FAILED ${jobid} - ERROR RUNNING wsr_ecmwfensh - ABNORMAL EXIT"
-    fi
+  else
+    set +x
+    echo " "
+    echo "FATAL ERROR:  An error occurred while running wsr_ecmwfensh "
+    echo "!!! which is the program for ECgrib1-NCEPgrib1             "
+    echo "!!! Return code from wsr_ecmwfensh = ${ecmwfrcc} "
+    echo "!!! Exiting...at ${ymdh}_${vhour}"
+    echo " "
+    set -x
+    err_exit "FAILED ${jobid} - ERROR RUNNING wsr_ecmwfensh - ABNORMAL EXIT"
+  fi
 
 #    if [[ -s tmpt200 ]]; then
 #      cat tmpt200      >>ensposte.$prev_cycle.t200hr
@@ -333,10 +333,10 @@ echo "The time just before copying begins is: `date`"
 #    fi
 
 #    rm tmp*
-  else
-    echo "!!! file ${ifile} is not copied !!!"
-    echo "   "
-  fi
+else
+  echo "!!! file ${ifile} is not copied !!!"
+  echo "   "
+fi
 
 #--------J.Peng---2010-12-13----------------------------------------------
 ## test output copy may be removed
@@ -351,7 +351,7 @@ echo "The time just before copying begins is: `date`"
 #    fi
 ####e
 
-  echo `date` end "vmdh = $vmdh"
+echo `date` end "vmdh = $vmdh"
 
 #  let hourix=hourix+1
 #done


### PR DESCRIPTION
Previously, ECMWF ensemble member runs used DCE files that included both perturbed and control members. In the updated dataset, control members are no longer included. As a result, any references to the control member (C00) have been removed from the workflow. Control member runs are now handled separately within the ECMWF processing.